### PR TITLE
Using aptIsActive for libctru v2.0.0

### DIFF
--- a/m3dialib/source/core/applet.cpp
+++ b/m3dialib/source/core/applet.cpp
@@ -139,10 +139,8 @@ namespace m3d {
         u32 aptbuf[0x400 / 4];
 
         memset(aptbuf, 0, sizeof(aptbuf));
-        if (!aptLaunchLibraryApplet(id, aptbuf, sizeof(aptbuf), 0))
-            return false;
-
-        return true;
+        aptLaunchLibraryApplet(id, aptbuf, sizeof(aptbuf), 0);
+        return aptIsActive();
     }
 
     m3d::Applet::ConsoleModel Applet::getConsoleModel() {


### PR DESCRIPTION
I noticed the lib don't compile against the latest libctru, after digging the release notes, it appears the `aptLaunchLibraryApplet` no longer return, instead new functions are needed to fetch the applet states. I used `aptIsActive`, hopefully this works.

https://github.com/devkitPro/libctru/releases/tag/v2.0.0